### PR TITLE
Remove unused project relation from category schema

### DIFF
--- a/src/api/category/content-types/category/schema.json
+++ b/src/api/category/content-types/category/schema.json
@@ -24,12 +24,6 @@
       "relation": "oneToMany",
       "target": "api::property.property",
       "mappedBy": "category"
-    },
-    "project": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::project.project",
-      "mappedBy": "category"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the direct one-to-one relationship between categories and projects. Categories are no longer linked to a single project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->