### PR TITLE
Remove columnType definition for price in building material schema

### DIFF
--- a/src/api/building-material/content-types/building-material/schema.json
+++ b/src/api/building-material/content-types/building-material/schema.json
@@ -25,7 +25,6 @@
     },
     "price": {
       "type": "decimal",
-      "columnType": "decimal(10,2)",
       "required": true
     },
     "priceUpwardTrend": {


### PR DESCRIPTION
Remove columnType definition for price in building material schema to simplify the schema structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the definition of the "price" field for building materials to improve compatibility, without changing its required status or data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->